### PR TITLE
프리뷰버전 렌더드래곤 디퍼드 번역 오류

### DIFF
--- a/texts/ko_KR.lang
+++ b/texts/ko_KR.lang
@@ -1734,6 +1734,8 @@ createWorldScreen.clearPlayerData.all=모든 플레이어 데이터	#
 createWorldScreen.clearPlayerData.allExceptLocal=플레이어 데이터 유지	#
 createWorldScreen.clearPlayerData.cancel=취소	#
 createWorldScreen.clearPlayerData.progress=플레이어 데이터 지우는 중	#
+createWorldScreen.experimentalDeferredTechnicalPreview=제작자용 렌더드래곤 기능	#
+createWorldScreen.experimentalDeferredTechnicalPreviewDescription=디퍼드 렌더링 파이프라인을 활성화합니다. PBR 지원 리소스 팩 및 호환되는 하드웨어가 필요합니다.	#
 
 
 ## Cross Platform Toggle


### PR DESCRIPTION
render dragon을 드래곤 렌더링으로 번역한 오류 수정
Deferred를 지연된으로 오역한부분 수정 (번역이 통일화 되지 않았고 렌더 기술명이라 디퍼드로 번역되는게 맞음)